### PR TITLE
Update store products

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,3 +51,4 @@ celery==3.1.21
 django-docopt-command==0.2.2
 PyYAML==3.11
 GitPython==1.0.2
+lxml==3.6.0

--- a/spistresci/stores/datasource/generic.py
+++ b/spistresci/stores/datasource/generic.py
@@ -1,9 +1,12 @@
+import logging
 import re
 from lxml import etree
 from urllib.request import urlopen, Request
 
 from spistresci.stores.models import Store
 from spistresci.stores.utils.datastoragemanager import DataStorageManager
+
+logger = logging.getLogger(__name__)
 
 
 class DataSource:
@@ -45,7 +48,7 @@ class DataSource:
         available_revision = self.ds_manager.last_revision_number()
         store, new = Store.objects.get_or_create(name=self.name, url=self.store_url)
 
-        if new:
+        if new or store.last_update_revision is None:
             products = self._extract(available_revision)
             store.update_products(revision_number=available_revision, added=products)
         elif store.last_update_revision < available_revision:
@@ -68,7 +71,7 @@ class XmlDataSource(DataSource):
         can be retrieved later by providing name and filename
         """
 
-        print('fetch files for {}'.format(self.name))
+        logger.info('fetch files for {}'.format(self.name))
 
         filename = '{}.xml'.format(self.name.lower())
 

--- a/spistresci/stores/datasource/generic.py
+++ b/spistresci/stores/datasource/generic.py
@@ -1,3 +1,5 @@
+import re
+from lxml import etree
 from urllib.request import urlopen, Request
 from spistresci.stores.utils.datastoragemanager import DataStorageManager
 
@@ -29,6 +31,27 @@ class DataSource:
     def fetch(self):
         pass
 
+    def _extract(self, *args, **kwargs):
+        pass
+
+    def _filter(self, *args, **kwargs):
+        pass
+
+    def _submit(self, *args, **kwargs):
+        pass
+
+    def update(self):
+        """
+        1. extract - get data from raw source (i.e. parse json/xml and convert to dict)
+        2. filter - filter out only those items which need to be updated
+        3. submit - insert/delete/update products in database
+
+        """
+
+        e = self._extract()
+        f = self._filter(e)
+        self._submit(f)
+
 
 class XmlDataSource(DataSource):
 
@@ -57,3 +80,80 @@ class XmlDataSource(DataSource):
                 buffer.write(chunk)
 
         return filename
+
+    def _extract(self, *args, **kwargs):
+
+        file_name = '{}.xml'.format(self.name.lower())
+        file_content = DataStorageManager(self.name).get(file_name)
+
+        return [
+            self._make_dict(product_xml_node)
+            for product_xml_node in self._get_product_list(file_content)
+        ]
+
+    def _filter(self, *args, **kwargs):
+        pass
+
+    def _submit(self, *args, **kwargs):
+        pass
+
+    # code below is inherited from SpisTresci 1.0. Refactor is welcome :)
+
+    xml_tag_dict = None
+    xmls_namespace = ''
+    depth = 0
+
+    def _get_product_list(self, file_content):
+        root = etree.fromstring(str.encode(file_content))
+        return list(self._we_have_to_go_deeper(root, self.depth))
+
+    def _we_have_to_go_deeper(self, root, depth):
+        for i in range(int(depth)):
+            root = root[0]
+        return root
+
+    def _make_dict(self, product, xml_tag_dict=None):
+        """
+        Translate product xml into dictionary used to insert into database
+        :param product: product xml root
+        :param xml_tag_dict: dictionary of xpaths used to translate
+        :return: created dictionary
+        """
+
+        xml_tag_dict = xml_tag_dict or self.xml_tag_dict
+
+        product_dict = {}
+        for (dict_key, xpath) in xml_tag_dict.items():
+            (tag, default_0) = xpath
+            regex = re.compile("([^{]*)({.*})?")
+            recurency = regex.search(tag).groups()
+            ntag = recurency[0]
+            elems = product.xpath(ntag, namespaces=self.xmls_namespace)
+            for elem in elems:
+                if recurency[1] != None:
+                    self._get_dict_from_elem(eval(recurency[1]), dict_key, elem, tag, product_dict)
+                else:
+                    self._get_value_from_elem(dict_key, default_0, elem, ntag, product_dict)
+
+            product_dict.setdefault(dict_key, (str(default_0) if default_0 != None else None))
+
+            if product_dict[dict_key] != None and len(product_dict[dict_key]) == 1:
+                product_dict[dict_key] = product_dict[dict_key][0]
+
+        return product_dict
+
+    def _get_dict_from_elem(self, xml_tag_dict, new_tag, elem, tag, product_dict):
+        if elem != None:
+            if product_dict.get(new_tag) == None:
+                product_dict[new_tag] = []
+
+            product_dict[new_tag].append(self._make_dict(elem, xml_tag_dict))
+
+    def _get_value_from_elem(self, new_tag, default_0, elem, tag, product_dict):
+        if elem != None:
+            if product_dict.get(new_tag) == None:
+                product_dict[new_tag] = []
+            if isinstance(elem, str):
+                product_dict[new_tag].append(str(elem))
+            else:
+                product_dict[new_tag].append(str(elem.text if elem.text != "" and elem.text != None else default_0))

--- a/spistresci/stores/datasource/generic.py
+++ b/spistresci/stores/datasource/generic.py
@@ -10,6 +10,7 @@ class DataSource:
         self.name = store_config['name']
         self.url = store_config['data_source']['url']
         self.type = store_config['data_source']['type']
+        self.ds_manager = DataStorageManager(self.name)
 
     @staticmethod
     def get_all_subclasses():
@@ -48,9 +49,7 @@ class DataSource:
 
         """
 
-        e = self._extract()
-        f = self._filter(e)
-        self._submit(f)
+        self._submit(**self._filter(**self._extract()))
 
 
 class XmlDataSource(DataSource):
@@ -70,8 +69,7 @@ class XmlDataSource(DataSource):
         response = urlopen(request)
 
         chunk_size = 16 * 1024
-        ds_manager = DataStorageManager(self.name)
-        with ds_manager.save(filename) as buffer:
+        with self.ds_manager.save(filename) as buffer:
             while True:
                 chunk = response.read(chunk_size)
                 if not chunk:
@@ -84,17 +82,64 @@ class XmlDataSource(DataSource):
     def _extract(self, *args, **kwargs):
 
         file_name = '{}.xml'.format(self.name.lower())
-        file_content = DataStorageManager(self.name).get(file_name)
+        revision_number = self.ds_manager.last_revision_number()
+        file_content = self.ds_manager.get(file_name, revision=revision_number)
 
-        return [
+        products = [
             self._make_dict(product_xml_node)
             for product_xml_node in self._get_product_list(file_content)
         ]
 
-    def _filter(self, *args, **kwargs):
-        pass
+        return {
+            'revision_number': revision_number,
+            'file_name': file_name,
+            'products': products,
+        }
 
-    def _submit(self, *args, **kwargs):
+    def _filter(self, revision_number, file_name, products):
+
+        if revision_number == DataStorageManager.FIRST_REV_NUMBER:
+            # because this is first revision, all products are new
+            return {'added': products, 'deleted': [], 'modified': []}
+
+        prev_rev_number = revision_number - 1
+
+        new_product_dicts = {product['external_id']: product for product in products}
+
+        file_content = self.ds_manager.get(file_name, prev_rev_number)
+
+        old_products = [
+            self._make_dict(product_xml_node)
+            for product_xml_node in self._get_product_list(file_content)
+        ]
+
+        old_product_dicts = {product['external_id']: product for product in old_products}
+
+        products_added = [
+            new_product_dicts[key]
+            for key in list(set(new_product_dicts.keys()) - set(old_product_dicts.keys()))
+        ]
+        products_deleted = [
+            old_product_dicts[key]
+            for key in list(set(old_product_dicts.keys()) - set(new_product_dicts.keys()))
+        ]
+
+        products_modified = [
+            old_product_dicts[key]
+            for key in set(old_product_dicts.keys()).intersection(set(new_product_dicts.keys()))
+            if old_product_dicts[key] != new_product_dicts[key]
+        ]
+
+        return {
+            'added': products_added,
+            'deleted': products_deleted,
+            'modified': products_modified,
+        }
+
+    def _submit(self, added, deleted, modified):
+        print('To add: {}'.format(len(added)))
+        print('To delete: {}'.format(len(deleted)))
+        print('To modify: {}'.format(len(modified)))
         pass
 
     # code below is inherited from SpisTresci 1.0. Refactor is welcome :)
@@ -130,30 +175,30 @@ class XmlDataSource(DataSource):
             ntag = recurency[0]
             elems = product.xpath(ntag, namespaces=self.xmls_namespace)
             for elem in elems:
-                if recurency[1] != None:
+                if recurency[1] is not None:
                     self._get_dict_from_elem(eval(recurency[1]), dict_key, elem, tag, product_dict)
                 else:
                     self._get_value_from_elem(dict_key, default_0, elem, ntag, product_dict)
 
-            product_dict.setdefault(dict_key, (str(default_0) if default_0 != None else None))
+            product_dict.setdefault(dict_key, (str(default_0) if default_0 is not None else None))
 
-            if product_dict[dict_key] != None and len(product_dict[dict_key]) == 1:
+            if product_dict[dict_key] is not None and len(product_dict[dict_key]) == 1:
                 product_dict[dict_key] = product_dict[dict_key][0]
 
         return product_dict
 
     def _get_dict_from_elem(self, xml_tag_dict, new_tag, elem, tag, product_dict):
-        if elem != None:
-            if product_dict.get(new_tag) == None:
+        if elem is not None:
+            if product_dict.get(new_tag) is None:
                 product_dict[new_tag] = []
 
             product_dict[new_tag].append(self._make_dict(elem, xml_tag_dict))
 
     def _get_value_from_elem(self, new_tag, default_0, elem, tag, product_dict):
-        if elem != None:
-            if product_dict.get(new_tag) == None:
+        if elem is not None:
+            if product_dict.get(new_tag) is None:
                 product_dict[new_tag] = []
             if isinstance(elem, str):
                 product_dict[new_tag].append(str(elem))
             else:
-                product_dict[new_tag].append(str(elem.text if elem.text != "" and elem.text != None else default_0))
+                product_dict[new_tag].append(str(elem.text if elem.text != "" and elem.text is not None else default_0))

--- a/spistresci/stores/datasource/generic.py
+++ b/spistresci/stores/datasource/generic.py
@@ -35,10 +35,10 @@ class DataSource:
     def fetch(self):
         pass
 
-    def _extract(self, *args, **kwargs):
+    def _extract(self, revision):
         pass
 
-    def _filter(self, *args, **kwargs):
+    def _filter(self, products, prev_rev_number):
         pass
 
     def update(self):

--- a/spistresci/stores/datasource/generic.py
+++ b/spistresci/stores/datasource/generic.py
@@ -120,7 +120,7 @@ class XmlDataSource(DataSource):
         ]
 
         products_modified = [
-            old_product_dicts[key]
+            new_product_dicts[key]
             for key in set(old_product_dicts.keys()).intersection(set(new_product_dicts.keys()))
             if old_product_dicts[key] != new_product_dicts[key]
         ]

--- a/spistresci/stores/datasource/specific/publio.py
+++ b/spistresci/stores/datasource/specific/publio.py
@@ -2,4 +2,16 @@ from spistresci.stores.datasource.generic import XmlDataSource
 
 
 class Publio(XmlDataSource):
-    pass
+    xml_tag_dict = {
+        'external_id': ('./id', ''),
+        'title': ('./title', ''),
+        'authors': ('./authors', ''),
+        'formats': ('./formats', ''),
+        'protection': ('./protectionType', ''),
+        'price': ('./price', ''),
+        'url': ('./productUrl', ''),
+        'cover': ('./imageUrl', ''),
+        'isbns': ('./isbns', ''),
+        'publisher': ('./company', ''),
+        'category': ('./categories/category', ''),
+    }

--- a/spistresci/stores/management/commands/fetch_store_products.py
+++ b/spistresci/stores/management/commands/fetch_store_products.py
@@ -12,7 +12,10 @@ class Command(DocOptCommand):
     '''
 
     def handle_docopt(self, arguments):
-        manager = StoreManager(store_names=arguments['<store_name>'] if not arguments['--all'] else None)
+        try:
+            manager = StoreManager(store_names=arguments['<store_name>'] if not arguments['--all'] else None)
+        except StoreManager.MissingStoreInStoresConfigException as e:
+            exit(e.args[0])
 
         for store in manager.get_stores():
             store.fetch()

--- a/spistresci/stores/management/commands/fetch_store_products.py
+++ b/spistresci/stores/management/commands/fetch_store_products.py
@@ -1,5 +1,4 @@
 from django_docopt_command import DocOptCommand
-
 from spistresci.stores.manager import StoreManager
 
 
@@ -7,10 +6,13 @@ class Command(DocOptCommand):
     docs = '''Usage:
     fetch_store_products <store_name>...
     fetch_store_products --all
+
+    Options:
+      -a --all     Fetches data for all stores configured in config
     '''
 
     def handle_docopt(self, arguments):
-        manager = StoreManager(stores=arguments['<store_name>'] if not arguments['--all'] else None)
+        manager = StoreManager(store_names=arguments['<store_name>'] if not arguments['--all'] else None)
 
         for store in manager.get_stores():
             store.fetch()

--- a/spistresci/stores/management/commands/update_store_products.py
+++ b/spistresci/stores/management/commands/update_store_products.py
@@ -1,5 +1,7 @@
 from django_docopt_command import DocOptCommand
 
+from spistresci.stores.manager import StoreManager
+
 
 class Command(DocOptCommand):
     docs = '''Usage:
@@ -7,5 +9,8 @@ class Command(DocOptCommand):
     update_store_products --all
     '''
 
-    def handle_docopt(self, aruments):
-        pass
+    def handle_docopt(self, arguments):
+        manager = StoreManager(stores=arguments['<store_name>'] if not arguments['--all'] else None)
+
+        for store in manager.get_stores():
+            store.update()

--- a/spistresci/stores/management/commands/update_store_products.py
+++ b/spistresci/stores/management/commands/update_store_products.py
@@ -8,10 +8,16 @@ class Command(DocOptCommand):
     docs = '''Usage:
     update_store_products <store_name>...
     update_store_products --all
+
+    Options:
+      -a --all     Updates all stores configured in config
     '''
 
     def handle_docopt(self, arguments):
-        manager = StoreManager(stores=arguments['<store_name>'] if not arguments['--all'] else None)
+        try:
+            manager = StoreManager(store_names=arguments['<store_name>'] if not arguments['--all'] else None)
+        except StoreManager.MissingStoreInStoresConfigException as e:
+            exit(e.args[0])
 
         for store in manager.get_stores():
             try:

--- a/spistresci/stores/management/commands/update_store_products.py
+++ b/spistresci/stores/management/commands/update_store_products.py
@@ -1,6 +1,7 @@
 from django_docopt_command import DocOptCommand
 
 from spistresci.stores.manager import StoreManager
+from spistresci.stores.utils.datastoragemanager import DataStorageManager
 
 
 class Command(DocOptCommand):
@@ -13,4 +14,7 @@ class Command(DocOptCommand):
         manager = StoreManager(stores=arguments['<store_name>'] if not arguments['--all'] else None)
 
         for store in manager.get_stores():
-            store.update()
+            try:
+                store.update()
+            except DataStorageManager.NoRevision:
+                print('WARNING: {} cannot be updated. There is no fetched data for it.'.format(store.name))

--- a/spistresci/stores/models.py
+++ b/spistresci/stores/models.py
@@ -9,5 +9,7 @@ class Store(models.Model):
     url = models.URLField(_('Store url address'))
     last_update_revision = models.IntegerField(null=True)
 
-    def update_products(self, revision, added, deleted, modified):
-        pass
+    def update_products(self, revision, added=None, deleted=None, modified=None):
+        added = added or []
+        deleted = deleted or []
+        modified = modified or []

--- a/spistresci/stores/models.py
+++ b/spistresci/stores/models.py
@@ -7,3 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 class Store(models.Model):
     name = models.CharField(_('Store name'), max_length=32)
     url = models.URLField(_('Store url address'))
+    last_update_revision = models.IntegerField(null=True)
+
+    def update_products(self, revision, added, deleted, modified):
+        pass

--- a/spistresci/stores/models.py
+++ b/spistresci/stores/models.py
@@ -9,7 +9,7 @@ class Store(models.Model):
     url = models.URLField(_('Store url address'))
     last_update_revision = models.IntegerField(null=True)
 
-    def update_products(self, revision, added=None, deleted=None, modified=None):
+    def update_products(self, revision_number, added=None, deleted=None, modified=None):
         added = added or []
         deleted = deleted or []
         modified = modified or []

--- a/spistresci/stores/tests/datasource/test_generic.py
+++ b/spistresci/stores/tests/datasource/test_generic.py
@@ -6,6 +6,7 @@ from django.test.utils import override_settings
 from spistresci.stores.config import Config
 from spistresci.stores.datasource.generic import XmlDataSource
 from spistresci.stores.manager import StoreManager
+from spistresci.stores.models import Store
 
 
 @override_settings(ST_STORES_CONFIG='spistresci/stores/tests/datasource/configs/test_xmldatasource.yml')
@@ -13,6 +14,7 @@ class TestXmlDataSource(TestCase):
 
     def setUp(self):
         Config.read()
+        self.store_config = Config.get()['stores']['xmldatasource']
 
     def test_data_source_is_instance_of_XmlDataSource(self):
         data_source = StoreManager().get_store('xmldatasource')
@@ -30,5 +32,27 @@ class TestXmlDataSource(TestCase):
         data_source = StoreManager().get_store('xmldatasource')
         data_source.fetch()
 
-        data_storage_manager.assert_has_calls([call('Foo')])
+        data_storage_manager.assert_has_calls([call(self.store_config['name'])])
         data_storage_manager.return_value.save.assert_has_calls([call('foo.xml')])
+
+    @patch('spistresci.stores.datasource.generic.Store.update_products')
+    @patch('spistresci.stores.datasource.generic.DataStorageManager.get')
+    @patch('spistresci.stores.datasource.generic.DataStorageManager.last_revision_number')
+    def test_update_should_update_data_only_if_new_revision_is_available(self, last_revision_number, get, update_products):
+        Store.objects.create(name=self.store_config['name'], url=self.store_config['url'], last_update_revision=42)
+        data_source = StoreManager().get_store('xmldatasource')
+        get.return_value = '<products></products>'
+
+        last_revision_number.return_value = 42
+        data_source.update()
+        self.assertEqual(update_products.call_count, 0)
+
+        last_revision_number.return_value = 43
+        data_source.update()
+        update_products.assert_called_once_with(43, [], [], [])
+
+    # def test_update_creates_store_if_it_does_not_exist(self):
+    #     self.assertEqual(Store.objects.count(), 0)
+    #     data_source = StoreManager().get_store('xmldatasource')
+    #     data_source.update()
+    #     self.assertEqual(Store.objects.count(), 1)

--- a/spistresci/stores/tests/datasource/test_generic.py
+++ b/spistresci/stores/tests/datasource/test_generic.py
@@ -13,10 +13,10 @@ class TestXmlDataSource(TestCase):
 
     def setUp(self):
         Config.read()
-        self.data_source = StoreManager().get_store('xmldatasource')
 
     def test_data_source_is_instance_of_XmlDataSource(self):
-        self.assertIsInstance(self.data_source, XmlDataSource)
+        data_source = StoreManager().get_store('xmldatasource')
+        self.assertIsInstance(data_source, XmlDataSource)
 
     @patch('spistresci.stores.datasource.generic.DataStorageManager')
     @patch('spistresci.stores.datasource.generic.urlopen')
@@ -27,7 +27,8 @@ class TestXmlDataSource(TestCase):
 
         data_storage_manager.return_value.save = MagicMock()
 
-        self.data_source.fetch()
+        data_source = StoreManager().get_store('xmldatasource')
+        data_source.fetch()
 
         data_storage_manager.assert_has_calls([call('Foo')])
         data_storage_manager.return_value.save.assert_has_calls([call('foo.xml')])

--- a/spistresci/stores/tests/datasource/test_generic.py
+++ b/spistresci/stores/tests/datasource/test_generic.py
@@ -7,6 +7,7 @@ from spistresci.stores.config import Config
 from spistresci.stores.datasource.generic import XmlDataSource
 from spistresci.stores.manager import StoreManager
 from spistresci.stores.models import Store
+from spistresci.stores.utils.datastoragemanager import DataStorageManager
 
 
 @override_settings(ST_STORES_CONFIG='spistresci/stores/tests/datasource/configs/test_xmldatasource.yml')
@@ -64,5 +65,7 @@ class TestXmlDataSource(TestCase):
         data_source.update()
         self.assertEqual(Store.objects.count(), 1)
 
-    # def test_update_raises_no_revision_exception_if_there_is_no_data_in_ds(self):
-    #     pass
+    def test_update_raises_no_revision_exception_if_there_is_no_data_in_ds(self):
+        data_source = StoreManager().get_store('xmldatasource')
+        with self.assertRaises(DataStorageManager.NoRevision):
+            data_source.update()

--- a/spistresci/stores/tests/datasource/test_generic.py
+++ b/spistresci/stores/tests/datasource/test_generic.py
@@ -17,7 +17,8 @@ class TestXmlDataSource(TestCase):
         Config.read()
         self.store_config = Config.get()['stores']['xmldatasource']
 
-    def test_data_source_is_instance_of_XmlDataSource(self):
+    @patch('spistresci.stores.datasource.generic.DataStorageManager')
+    def test_data_source_is_instance_of_XmlDataSource(self, data_storage_manager):
         data_source = StoreManager().get_store('xmldatasource')
         self.assertIsInstance(data_source, XmlDataSource)
 
@@ -37,35 +38,36 @@ class TestXmlDataSource(TestCase):
         data_storage_manager.return_value.save.assert_has_calls([call('foo.xml')])
 
     @patch('spistresci.stores.datasource.generic.Store.update_products')
-    @patch('spistresci.stores.datasource.generic.DataStorageManager.get')
-    @patch('spistresci.stores.datasource.generic.DataStorageManager.last_revision_number')
-    def test_update_should_update_data_only_if_new_revision_is_available(self, last_revision_number, get, update_products):
+    @patch('spistresci.stores.datasource.generic.DataStorageManager')
+    def test_update_should_update_data_only_if_new_revision_is_available(self, data_storage_manager, update_products):
         Store.objects.create(name=self.store_config['name'], url=self.store_config['url'], last_update_revision=42)
         data_source = StoreManager().get_store('xmldatasource')
-        get.return_value = '<products></products>'
+        data_storage_manager.return_value.get.return_value = '<products></products>'
 
-        last_revision_number.return_value = 42
+        data_storage_manager.return_value.last_revision_number.return_value = 42
         data_source.update()
         self.assertEqual(update_products.call_count, 0)
 
-        last_revision_number.return_value = 43
+        data_storage_manager.return_value.last_revision_number.return_value = 43
         data_source.update()
         update_products.assert_called_once_with(revision_number=43, added=[], deleted=[], modified=[])
 
     @patch('spistresci.stores.datasource.generic.Store.update_products')
-    @patch('spistresci.stores.datasource.generic.DataStorageManager.get')
-    @patch('spistresci.stores.datasource.generic.DataStorageManager.last_revision_number')
-    def test_update_creates_store_if_it_does_not_exist(self, last_revision_number, get, update_products):
+    @patch('spistresci.stores.datasource.generic.DataStorageManager')
+    def test_update_creates_store_if_it_does_not_exist(self, data_storage_manager, update_products):
         self.assertEqual(Store.objects.count(), 0)
 
-        get.return_value = '<products></products>'
-        last_revision_number.return_value = 0
+        data_storage_manager.return_value.get.return_value = '<products></products>'
+        data_storage_manager.return_value.last_revision_number.return_value = 0
 
         data_source = StoreManager().get_store('xmldatasource')
         data_source.update()
         self.assertEqual(Store.objects.count(), 1)
 
-    def test_update_raises_no_revision_exception_if_there_is_no_data_in_ds(self):
+    @patch('spistresci.stores.datasource.generic.DataStorageManager')
+    def test_update_passes_no_revision_exception_if_there_is_no_data_in_ds(self, data_storage_manager):
+        data_storage_manager.return_value.last_revision_number.side_effect = DataStorageManager.NoRevision()
+
         data_source = StoreManager().get_store('xmldatasource')
         with self.assertRaises(DataStorageManager.NoRevision):
             data_source.update()

--- a/spistresci/stores/tests/datasource/test_generic.py
+++ b/spistresci/stores/tests/datasource/test_generic.py
@@ -49,10 +49,20 @@ class TestXmlDataSource(TestCase):
 
         last_revision_number.return_value = 43
         data_source.update()
-        update_products.assert_called_once_with(43, [], [], [])
+        update_products.assert_called_once_with(revision_number=43, added=[], deleted=[], modified=[])
 
-    # def test_update_creates_store_if_it_does_not_exist(self):
-    #     self.assertEqual(Store.objects.count(), 0)
-    #     data_source = StoreManager().get_store('xmldatasource')
-    #     data_source.update()
-    #     self.assertEqual(Store.objects.count(), 1)
+    @patch('spistresci.stores.datasource.generic.Store.update_products')
+    @patch('spistresci.stores.datasource.generic.DataStorageManager.get')
+    @patch('spistresci.stores.datasource.generic.DataStorageManager.last_revision_number')
+    def test_update_creates_store_if_it_does_not_exist(self, last_revision_number, get, update_products):
+        self.assertEqual(Store.objects.count(), 0)
+
+        get.return_value = '<products></products>'
+        last_revision_number.return_value = 0
+
+        data_source = StoreManager().get_store('xmldatasource')
+        data_source.update()
+        self.assertEqual(Store.objects.count(), 1)
+
+    # def test_update_raises_no_revision_exception_if_there_is_no_data_in_ds(self):
+    #     pass

--- a/spistresci/stores/tests/management/test_fetch_store_products.py
+++ b/spistresci/stores/tests/management/test_fetch_store_products.py
@@ -8,27 +8,27 @@ from spistresci.stores.tests.management.util import call_docopt_command
 
 
 @override_settings(ST_STORES_CONFIG='spistresci/stores/tests/datasource/configs/test_xmldatasource.yml')
-class TestUpdateStoreProducts(TestCase):
+class TestFetchStoreProducts(TestCase):
 
-    @patch('spistresci.stores.management.commands.update_store_products.StoreManager')
-    def test__all_stores_are_updated(self, store_manager):
+    @patch('spistresci.stores.management.commands.fetch_store_products.StoreManager')
+    def test__data_from_all_stores_are_fetched(self, store_manager):
         mocked_store = MagicMock()
         store_manager.return_value.get_stores.return_value = [mocked_store] * 13
 
-        call_docopt_command('update_store_products', '--all')
+        call_docopt_command('fetch_store_products', '--all')
 
-        self.assertEqual(mocked_store.update.call_count, 13)
+        self.assertEqual(mocked_store.fetch.call_count, 13)
 
-    @patch('spistresci.stores.management.commands.update_store_products.StoreManager')
-    def test__selected_stores_are_updated(self, store_manager):
+    @patch('spistresci.stores.management.commands.fetch_store_products.StoreManager')
+    def test__data_from_selected_stores_are_fetched(self, store_manager):
         foo = MagicMock()
         bar = MagicMock()
         store_manager.return_value.get_stores.return_value = [foo, bar]
 
-        call_docopt_command('update_store_products', 'Foo Bar')
+        call_docopt_command('fetch_store_products', 'Foo Bar')
 
-        foo.update.assert_called_once_with()
-        bar.update.assert_called_once_with()
+        foo.fetch.assert_called_once_with()
+        bar.fetch.assert_called_once_with()
 
     def test__not_existing_store_in_config_as_param_cause_cmd_to_fail(self):
         not_existing_store_name = 'NoFoo'
@@ -38,4 +38,4 @@ class TestUpdateStoreProducts(TestCase):
         )
 
         with self.assertRaisesMessage(SystemExit, expected_msg):
-            call_docopt_command('update_store_products', not_existing_store_name)
+            call_docopt_command('fetch_store_products', not_existing_store_name)

--- a/spistresci/stores/tests/management/test_update_store_products.py
+++ b/spistresci/stores/tests/management/test_update_store_products.py
@@ -1,0 +1,65 @@
+from django.test.utils import override_settings
+from test_plus.test import TestCase
+from unittest.mock import patch, Mock, MagicMock, call
+
+from django.conf import settings
+from django.core.management import get_commands, load_command_class
+
+from spistresci.stores.config import Config
+from .util import capture_standard_out
+
+
+@override_settings(ST_STORES_CONFIG='spistresci/stores/tests/datasource/configs/test_xmldatasource.yml')
+class TestUpdateStoreProducts(TestCase):
+
+    def setUp(self):
+        Config.read()
+        self.store_config = Config.get()['stores']['xmldatasource']
+        pass
+
+    @patch('spistresci.stores.management.commands.update_store_products.StoreManager')
+    def test__all_stores_are_updated(self, store_manager):
+        mocked_store = MagicMock()
+        store_manager.return_value.get_stores.return_value = [mocked_store] * 13
+
+        call_docopt_command('update_store_products', '--all')
+
+        self.assertEqual(mocked_store.update.call_count, 13)
+
+    @patch('spistresci.stores.management.commands.update_store_products.StoreManager')
+    def test__selected_stores_are_updated(self, store_manager):
+        foo = MagicMock()
+        bar = MagicMock()
+        store_manager.return_value.get_stores.return_value = [foo, bar]
+
+        call_docopt_command('update_store_products', 'Foo Bar')
+
+        foo.update.assert_called_once_with()
+        bar.update.assert_called_once_with()
+
+    def test__not_existing_store_in_config_as_param_cause_cmd_to_fail(self):
+        not_existing_store_name = 'NoFoo'
+
+        expected_msg = "There is no '{}' store defined in '{}'".format(
+            not_existing_store_name, settings.ST_STORES_CONFIG
+        )
+
+        with self.assertRaisesMessage(SystemExit, expected_msg):
+            call_docopt_command('update_store_products', not_existing_store_name)
+
+
+def call_docopt_command(name, arg_string):
+    arguments = ['manage.py', name] + arg_string.split(' ')
+
+    command = get_command(name)
+
+    with capture_standard_out() as out:
+        command.run_from_argv(arguments)
+
+    stdout, _ = out
+    return stdout
+
+
+def get_command(name):
+    app_name = get_commands()[name]
+    return load_command_class(app_name, name)

--- a/spistresci/stores/tests/management/util.py
+++ b/spistresci/stores/tests/management/util.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from io import StringIO
 
+from django.core.management import get_commands, load_command_class
+
 
 @contextlib.contextmanager
 def capture_standard_out():
@@ -37,3 +39,20 @@ def capture_standard_out():
 
         sys.stderr.close()
         sys.stderr = previous_stderr
+
+
+def call_docopt_command(name, arg_string):
+    arguments = ['manage.py', name] + arg_string.split(' ')
+
+    command = get_command(name)
+
+    with capture_standard_out() as out:
+        command.run_from_argv(arguments)
+
+    stdout, _ = out
+    return stdout
+
+
+def get_command(name):
+    app_name = get_commands()[name]
+    return load_command_class(app_name, name)

--- a/spistresci/stores/tests/management/util.py
+++ b/spistresci/stores/tests/management/util.py
@@ -1,0 +1,39 @@
+import sys
+import contextlib
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+
+@contextlib.contextmanager
+def capture_standard_out():
+    """
+    Capture stdout and stderr. Returns list with [stdout, stderr]
+    with capture_standard_out() as out:
+        # do stuff
+        pass
+    stdout, stderr = out
+    """
+    previous_stdout = sys.stdout
+    previous_stderr = sys.stderr
+
+    out_stdout = StringIO()
+    out_stderr = StringIO()
+    out = [out_stdout, out_stderr]
+
+    try:
+        sys.stdout = out[0]
+        sys.stderr = out[1]
+
+        yield out
+    finally:
+        out[0] = out[0].getvalue()
+        out[1] = out[1].getvalue()
+
+        sys.stdout.close()
+        sys.stdout = previous_stdout
+
+        sys.stderr.close()
+        sys.stderr = previous_stderr

--- a/spistresci/stores/tests/utils/test_data_storage_manager.py
+++ b/spistresci/stores/tests/utils/test_data_storage_manager.py
@@ -1,3 +1,4 @@
+import traceback
 from tempfile import TemporaryDirectory
 from test_plus.test import TestCase
 
@@ -14,10 +15,16 @@ class TestDataStorageManager(TestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    def test_data_are_saved(self):
+    def _func_name(self):
+        """
+        To avoid using the same store_name for different tests, you can
+        use testcase function name as store_name
+        """
+        return traceback.extract_stack(None, 2)[0][2]
 
+    def test_data_are_saved(self):
         with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):
-            ds_manager = DataStorageManager('the store name')
+            ds_manager = DataStorageManager(self._func_name())
             with ds_manager.save('file.xml') as buffer:
                 buffer.write(b'data part 1')
                 buffer.write(b'data part 2')
@@ -25,3 +32,57 @@ class TestDataStorageManager(TestCase):
             content = ds_manager.get('file.xml')
 
         self.assertEqual(content, 'data part 1data part 2')
+
+    def test_last_revision_number_is_0_at_the_beginning(self):
+        with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):
+            ds_manager = DataStorageManager(self._func_name())
+            self.assertEqual(ds_manager.last_revision_number(), 0)
+
+    def test_last_revision_number_increase_after_each_save(self):
+        with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):
+            ds_manager = DataStorageManager(self._func_name())
+            self.assertEqual(ds_manager.last_revision_number(), 0)
+
+            with ds_manager.save('file.xml') as buffer:
+                buffer.write(b'data part 1')
+
+            self.assertEqual(ds_manager.last_revision_number(), 1)
+
+            with ds_manager.save('file.xml') as buffer:
+                buffer.write(b'data part 1')
+                buffer.write(b'data part 2')
+
+            self.assertEqual(ds_manager.last_revision_number(), 2)
+
+    def test_last_revision_number_do_not_depend_on_filename(self):
+        with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):
+            ds_manager = DataStorageManager(self._func_name())
+            self.assertEqual(ds_manager.last_revision_number(), 0)
+
+            with ds_manager.save('file1.xml') as buffer:
+                buffer.write(b'data part 1')
+
+            self.assertEqual(ds_manager.last_revision_number(), 1)
+
+            with ds_manager.save('file2.xml') as buffer:
+                buffer.write(b'data part 1')
+
+            self.assertEqual(ds_manager.last_revision_number(), 2)
+
+    def test_last_revision_number_do_not_depend_on_store_name(self):
+        with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):
+            ds_manager = DataStorageManager(self._func_name() + '1')
+            self.assertEqual(ds_manager.last_revision_number(), 0)
+
+            with ds_manager.save('file1.xml') as buffer:
+                buffer.write(b'data part 1')
+
+            self.assertEqual(ds_manager.last_revision_number(), 1)
+
+            ds_manager = DataStorageManager(self._func_name() + '2')
+            self.assertEqual(ds_manager.last_revision_number(), 0)
+
+            with ds_manager.save('file1.xml') as buffer:
+                buffer.write(b'data part 1')
+
+            self.assertEqual(ds_manager.last_revision_number(), 1)

--- a/spistresci/stores/tests/utils/test_data_storage_manager.py
+++ b/spistresci/stores/tests/utils/test_data_storage_manager.py
@@ -40,12 +40,13 @@ class TestDataStorageManager(TestCase):
                 ds_manager.get('file.xml')
 
     def test_get_raises_no_revision_for_not_existing_revision(self):
-        ds_manager = DataStorageManager(self._func_name())
-        with ds_manager.save('file.xml') as buffer:
-            buffer.write(b'data part 1')
+        with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):
+            ds_manager = DataStorageManager(self._func_name())
+            with ds_manager.save('file.xml') as buffer:
+                buffer.write(b'data part 1')
 
-        with self.assertRaises(DataStorageManager.NoRevision):
-            ds_manager.get('file.xml', revision=999)
+            with self.assertRaises(DataStorageManager.NoRevision):
+                ds_manager.get('file.xml', revision=999)
 
     def test_get_raises_no_file_when_there_is_no_file(self):
         with override_settings(ST_STORES_DATA_DIR=self.temp_dir.name):

--- a/spistresci/stores/utils/datastoragemanager.py
+++ b/spistresci/stores/utils/datastoragemanager.py
@@ -46,6 +46,7 @@ class DataStorageManager:
         commit_msg = "Store: {}\nDate: {}".format(self.store_name, commit_datetime_str)
 
         self.repo.index.commit(commit_msg)
+
         self.__increment_revision()
 
     def get(self, filename, revision=None):
@@ -63,7 +64,10 @@ class DataStorageManager:
             raise DataStorageManager.NoFile()
 
         with open(file_path) as f:
-            return f.read()
+            content = f.read()
+
+        self.repo.git.checkout('master')
+        return content
 
     def __asert_is_clean(self):
         assert not self.repo.is_dirty(), "Repository '{}' is dirty. " \

--- a/spistresci/stores/utils/datastoragemanager.py
+++ b/spistresci/stores/utils/datastoragemanager.py
@@ -7,6 +7,7 @@ from django.conf import settings
 
 
 class DataStorageManager:
+    __revision_tag_name = 'rev-{}'
 
     def __init__(self, store_name):
         self.store_name = store_name
@@ -23,27 +24,41 @@ class DataStorageManager:
     @contextmanager
     def save(self, filename):
         self.__asert_is_clean()
-        filepath = os.path.join(self.store_storage_dir, filename)
+        file_path = os.path.join(self.store_storage_dir, filename)
 
-        file = open(filepath, 'wb')
+        file = open(file_path, 'wb')
         yield file
 
         file.close()
-        self.repo.index.add([filepath])
+        self.repo.index.add([file_path])
 
         commit_date = datetime.now()
         commit_datetime_str = commit_date.strftime("%Y-%m-%d %H:%M:%S")
         commit_msg = "Store: {}\nDate: {}".format(self.store_name, commit_datetime_str)
 
         self.repo.index.commit(commit_msg)
+        self.__increment_revision()
 
     def get(self, filename):
         self.__asert_is_clean()
 
-        filepath = os.path.join(self.store_storage_dir, filename)
-        with open(filepath) as f:
+        file_path = os.path.join(self.store_storage_dir, filename)
+        with open(file_path) as f:
             return f.read()
 
     def __asert_is_clean(self):
         assert not self.repo.is_dirty(), "Repository '{}' is dirty. " \
             "Has to be cleaned up before further work.".format(self.store_storage_dir)
+
+    def __increment_revision(self):
+        rev = self.last_revision_number()
+        self.repo.create_tag(self.__revision_tag_name.format(rev + 1))
+
+    def last_revision_number(self):
+        revisions = [
+            int(tag.name.replace(self.__revision_tag_name.format(''), ''))
+            for tag in self.repo.tags
+            if tag.name.startswith(self.__revision_tag_name.format(''))
+        ]
+
+        return 0 if not revisions else max(revisions)


### PR DESCRIPTION
There is new django managment command called `update_store_products`:
```

# python manage.py update_store_products --help
Usage:
    update_store_products <store_name>...
    update_store_products --all

    Options:
      -a --all     Updates all stores configured in config
    
```

Update do not fetch data from stores, so before calling `update_store_products` user have to use `fetch_store_products` command. 


