### PR TITLE
Date tags and commit only when new version of file is available 

### DIFF
--- a/spistresci/stores/utils/datastoragemanager.py
+++ b/spistresci/stores/utils/datastoragemanager.py
@@ -39,15 +39,16 @@ class DataStorageManager:
         yield file
 
         file.close()
-        self.repo.index.add([file_path])
 
-        commit_date = datetime.now()
-        commit_datetime_str = commit_date.strftime("%Y-%m-%d %H:%M:%S")
-        commit_msg = "Store: {}\nDate: {}".format(self.store_name, commit_datetime_str)
-
-        self.repo.index.commit(commit_msg)
+        date = datetime.now()
+        if self.repo.is_dirty():
+            self.repo.index.add([file_path])
+            commit_datetime_str = date.strftime("%Y-%m-%d %H:%M:%S")
+            commit_msg = "Store: {}\nDate: {}".format(self.store_name, commit_datetime_str)
+            self.repo.index.commit(commit_msg)
 
         self.__increment_revision()
+        self.repo.create_tag("date-{}".format(date.strftime("%Y-%m-%d_%H-%M-%S")))
 
     def get(self, filename, revision=None):
         self.__asert_is_clean()

--- a/spistresci/stores/utils/datastoragemanager.py
+++ b/spistresci/stores/utils/datastoragemanager.py
@@ -41,14 +41,20 @@ class DataStorageManager:
         file.close()
 
         date = datetime.now()
-        if self.repo.is_dirty():
+
+        try:
+            commits_counter = len(self.repo.git.log())
+        except GitCommandError:
+            commits_counter = 0
+
+        if self.repo.is_dirty() or commits_counter == 0:
             self.repo.index.add([file_path])
             commit_datetime_str = date.strftime("%Y-%m-%d %H:%M:%S")
             commit_msg = "Store: {}\nDate: {}".format(self.store_name, commit_datetime_str)
             self.repo.index.commit(commit_msg)
 
         self.__increment_revision()
-        self.repo.create_tag("date-{}".format(date.strftime("%Y-%m-%d_%H-%M-%S")))
+        self.repo.create_tag("date-{}".format(date.strftime("%Y-%m-%d_%H-%M-%S-%f")))
 
     def get(self, filename, revision=None):
         self.__asert_is_clean()


### PR DESCRIPTION
~~**Blocked by:** https://github.com/SpisTresci/SpisTresci/pull/20~~

> commit only when new version of file is available 

this should simplify analyzing what actually is new since last update

> Date tags

this will help find situation, where some stores are not updated for a long time (a lot of date tags on one commit). This is potential source of problem. Maybe API of store doesn't work, and things has to be investigated.